### PR TITLE
On FreeBSD 8+, the library is libmagic.so.4

### DIFF
--- a/lib/magic/api.rb
+++ b/lib/magic/api.rb
@@ -2,7 +2,7 @@ module Magic
   module Api #:nodoc:
     extend FFI::Library
 
-    lib_paths = Array(ENV["MAGIC_LIB"] || Dir["/{opt,usr}/{,local/}lib{,64}/libmagic.{1.dylib,so.1*}"])
+    lib_paths = Array(ENV["MAGIC_LIB"] || Dir["/{opt,usr}/{,local/}lib{,64}/libmagic.{1.dylib,so.1*,so.4}"])
     fallback_names = %w(libmagic.1.dylib libmagic.so.1 magic1.dll)
     ffi_lib(lib_paths + fallback_names)
 


### PR DESCRIPTION
On a default install of FreeBSD libmagic is installed in base as /usr/lib/libmagic.so as a symlink to /usr/lib/libmagic.so.4 in FreeBSD 8+.

Without this the gem can't find libmagic on FreeBSD hosts, unless you specific MAGIC_LIB in the environment everywhere.