### PR TITLE
Restore Magic::Exception for backwards compatibility

### DIFF
--- a/lib/magic/errors.rb
+++ b/lib/magic/errors.rb
@@ -2,4 +2,7 @@ module Magic
   # General Exception class
   class Error < StandardError
   end
+
+  # for backwards compatibility
+  Exception = Error
 end


### PR DESCRIPTION
Renaming Magic::Exception to Magic::Error breaks reverse dependencies
who where making calls to Magic#guess_* and rescuing Magic::Exception.
This will avoid them crashing on an undefined constant.